### PR TITLE
Function get_n_x_dims_spec must be a pure function since it is a specification function

### DIFF
--- a/source/spec/os-spec-define.f03
+++ b/source/spec/os-spec-define.f03
@@ -1013,7 +1013,7 @@ end subroutine
 ! - This will generally just be the same as p_x_dim
 ! - Some simulation modes may override this
 !-----------------------------------------------------------------------------------------
-function get_n_x_dims_spec( this )
+pure function get_n_x_dims_spec( this )
 
   implicit none
 


### PR DESCRIPTION
Fixes bug with Intel Oneapi mpiifx 2024.1, as pointed out in #8.